### PR TITLE
add peers as trusted domain

### DIFF
--- a/charm-nextcloud/src/utils.py
+++ b/charm-nextcloud/src/utils.py
@@ -1,4 +1,4 @@
-from subprocess import run, call
+from subprocess import run, call, PIPE
 
 
 def _modify_port(start=None, end=None, protocol='tcp', hook_tool="open-port"):
@@ -16,14 +16,50 @@ def _modify_port(start=None, end=None, protocol='tcp', hook_tool="open-port"):
     run([hook_tool, f"{port}{protocol}"])
 
 
-def occ_add_trusted_domain(domain,index):
+def occ_add_trusted_domain(domain, index):
     """
-    Adds a trusted domain to nextcloud with occ
+    Adds a trusted domain to nextcloud config.php with occ
     """
     add_trusted_domain = ("sudo -u www-data php /var/www/nextcloud/occ config:system:set "
                         "trusted_domains {index} "
                         " --value={domain} ").format(index=index,domain=domain)
     call(add_trusted_domain.split(), cwd='/var/www/nextcloud')
+
+def add_trusted_domain(domain):
+    """
+    Adds a trusted domain to nextcloud config.php
+    """
+    current_domains = occ_get_trusted_domains()
+    new_index = len(current_domains)
+    occ_add_trusted_domain(domain, new_index)
+
+def occ_remove_trusted_domain(domain):
+    """
+    Removes a trused domain from nextcloud with occ
+    """
+    current_domains = occ_get_trusted_domains()
+    if domain in current_domains:
+        current_domains.remove(domain)
+        # First delete all trusted domains from config.php since they might have indices not in order.
+        delete_trusted_domains = "sudo -u www-data php /var/www/nextcloud/occ config:system:delete trusted_domains"
+        run(delete_trusted_domains.split(), cwd='/var/www/nextcloud')
+        if current_domains:
+            # Now, add all the domains with indices in order starting from 0
+            for index, domain in enumerate(current_domains):
+                occ_add_trusted_domain(domain, index)
+
+def remove_trusted_domain(domain):
+    occ_remove_trusted_domain(domain)
+
+def occ_get_trusted_domains():
+    """
+    Get all current trusted domains in config.php with occ
+    return list
+    """
+    get_trusted_domain = "sudo -u www-data php /var/www/nextcloud/occ config:system:get trusted_domains"
+    output = run(get_trusted_domain.split(), cwd='/var/www/nextcloud', stdout=PIPE, universal_newlines=True)
+    domains = output.stdout.split()
+    return domains
 
 def enable_ping():
     _modify_port(None, None, protocol='icmp', hook_tool="open-port")


### PR DESCRIPTION
- adding peers assumes the indices are in order in config.php
- removing a peer will remove all domains from config.php, and then add them back in continuous index order, excluding the departed peer IP. With this, add_trusted_domain can assume indices are in order.

Removing a peer is not working in the charm yet since it seems like the unit data (IP-address) is not available in the relation-departed hook...

UPDATE:
The cluster relation trusted domains is updated on "model"-level. Which means it doesn't require the relation event from a hook.