### PR TITLE
Fix #20: nextcloud tarfile can be added as resource when deploying

### DIFF
--- a/charm-nextcloud-private/metadata.yaml
+++ b/charm-nextcloud-private/metadata.yaml
@@ -19,3 +19,9 @@ requires:
   redis:
     interface: redis
     optional: true
+
+resources:
+  nextcloud-tarfile:
+    type: file
+    filename: nextcloud.tar.bz2
+    description: Nextcloud tar file to use instead of downloading it.

--- a/charm-nextcloud-private/src/charm.py
+++ b/charm-nextcloud-private/src/charm.py
@@ -17,7 +17,8 @@ from ops.lib import use
 from ops.model import (
     ActiveStatus,
     BlockedStatus,
-    MaintenanceStatus
+    MaintenanceStatus,
+    ModelError
 )
 
 from nextcloud import utils
@@ -84,7 +85,11 @@ class NextcloudPrivateCharm(CharmBase):
         if not self._stored.nextcloud_fetched:
             # Fetch nextcloud to /var/www/
             self.unit.status = MaintenanceStatus("Begin fetching sources.")
-            utils.fetch_and_extract_nextcloud(self.config.get('nextcloud-tarfile'))
+            try:
+                tarfile_path = self.model.resources.fetch('nextcloud-tarfile')
+                utils.extract_nextcloud(tarfile_path)
+            except ModelError:
+                utils.fetch_and_extract_nextcloud(self.config.get('nextcloud-tarfile'))
             self.unit.status = MaintenanceStatus("Sources installed")
             self._stored.nextcloud_fetched = True
 

--- a/charm-nextcloud/metadata.yaml
+++ b/charm-nextcloud/metadata.yaml
@@ -23,3 +23,9 @@ requires:
 peers:
   cluster:
     interface: nextcloud-cluster
+
+resources:
+  nextcloud-tarfile:
+    type: file
+    filename: nextcloud.tar.bz2
+    description: Nextcloud tar file to use instead of downloading it.

--- a/charm-nextcloud/src/charm.py
+++ b/charm-nextcloud/src/charm.py
@@ -17,7 +17,8 @@ from ops.lib import use
 from ops.model import (
     ActiveStatus,
     BlockedStatus,
-    MaintenanceStatus
+    MaintenanceStatus,
+    ModelError
 )
 
 from nextcloud import utils
@@ -90,7 +91,11 @@ class NextcloudCharm(CharmBase):
         if not self._stored.nextcloud_fetched:
             # Fetch nextcloud to /var/www/
             self.unit.status = MaintenanceStatus("Begin fetching sources.")
-            utils.fetch_and_extract_nextcloud(self.config.get('nextcloud-tarfile'))
+            try:
+                tarfile_path = self.model.resources.fetch('nextcloud-tarfile')
+                utils.extract_nextcloud(tarfile_path)
+            except ModelError:
+                utils.fetch_and_extract_nextcloud(self.config.get('nextcloud-tarfile'))
             self.unit.status = MaintenanceStatus("Sources installed")
             self._stored.nextcloud_fetched = True
 

--- a/lib/nextcloud/utils.py
+++ b/lib/nextcloud/utils.py
@@ -87,6 +87,13 @@ def fetch_and_extract_nextcloud(tarfile_url):
         print(e)
         sys.exit(-1)
 
+def extract_nextcloud(tarfile_path):
+    """
+    Install nextcloud from tarfile
+    """
+    dst = Path('/var/www/')
+    with tarfile.open(tarfile_path, mode='r:bz2') as tfile:
+        tfile.extractall(path=dst)
 
 def config_apache2(templates_path, template):
     """


### PR DESCRIPTION
`juju deploy ./nextcloud.charm --resource nextcloud-tarfile=./nextcloud-18.0.3.tar.bz2`
or using bundle, add:
```
resources:
  nextcloud-tarfile: ./nextcloud-18.0.3.tar.bz2
```
