### PR TITLE
Fix #47: action for setting fqdn as trusted domain

### DIFF
--- a/charm-nextcloud-private/actions.yaml
+++ b/charm-nextcloud-private/actions.yaml
@@ -4,16 +4,13 @@
 # This is only an example, and you should edit to suit your needs.
 # If you don't need actions, you can remove the file entirely.
 # It ties in to the example _on_fortune_action handler in src/charm.py
-add-trusted-domain:
-  description: 'Adds a trusted domain by invoking <occ config:system:set trusted_domain>.'
+set-trusted-domain:
+  description: 'Set the trusted domain by invoking <occ config:system:set trusted_domain>.'
   params:
-    index:
-      description: 'nextcloud trusted_domains array'
-      type: integer
     domain:
-      decription: 'The domain --value=<example.com>'
+      decription: 'Domain name to set as trusted. E.g. domain=example.com.'
       type: string
-  required: [ index, domain ]
+  required: [ domain ]
 
 add-missing-indices:
   description: 'Runs occ db:add-missing-indices'

--- a/charm-nextcloud-private/src/charm.py
+++ b/charm-nextcloud-private/src/charm.py
@@ -57,7 +57,8 @@ class NextcloudPrivateCharm(CharmBase):
             self.db.on.database_relation_joined: self._on_database_relation_joined,
             self.db.on.master_changed: self._on_master_changed,
             self.on.update_status: self._on_update_status,
-            self.on.data_storage_attached: self._on_data_storage_attached
+            self.on.data_storage_attached: self._on_data_storage_attached,
+            self.on.set_trusted_domain_action: self._on_set_trusted_domain_action
         }
 
         # REDIS
@@ -298,13 +299,16 @@ class NextcloudPrivateCharm(CharmBase):
             self.unit.status = MaintenanceStatus("Adding local data storage.")
             self.install_mount_unitfile()
 
+    def _on_set_trusted_domain_action(self, event):
+        domain = event.params['domain']
+        Occ.config_system_set_trusted_domains(domain, 1)
 
-def _on_data_storage_detaching(self, event):
-    """
-    Remove the local storage flag.
-    """
-    self.unit.status = MaintenanceStatus("Removed data storage.")
-    self._stored.local_storage_attached = False
+    def _on_data_storage_detaching(self, event):
+        """
+        Remove the local storage flag.
+        """
+        self.unit.status = MaintenanceStatus("Removed data storage.")
+        self._stored.local_storage_attached = False
 
 
 if __name__ == "__main__":

--- a/charm-nextcloud/actions.yaml
+++ b/charm-nextcloud/actions.yaml
@@ -1,16 +1,13 @@
 # Copyright 2020 Erik Lönroth
 # See LICENSE file for licensing details.
 #
-add-trusted-domain:
-  description: 'Adds a trusted domain by invoking <occ config:system:set trusted_domain>.'
+set-trusted-domain:
+  description: 'Set the trusted domain by invoking <occ config:system:set trusted_domain>.'
   params:
-    index:
-      description: 'nextcloud trusted_domains array'
-      type: integer
     domain:
-      decription: 'The domain --value=<example.com>'
+      decription: 'Domain name to set as trusted. E.g. domain=example.com. Must run leader!'
       type: string
-  required: [ index, domain ]
+  required: [ domain ]
 
 add-missing-indices:
   description: 'Runs occ db:add-missing-indices'

--- a/charm-nextcloud/src/charm.py
+++ b/charm-nextcloud/src/charm.py
@@ -64,7 +64,8 @@ class NextcloudCharm(CharmBase):
             self.on.cluster_relation_changed: self._on_cluster_relation_changed,
             self.on.cluster_relation_joined: self._on_cluster_relation_joined,
             self.on.cluster_relation_departed: self._on_cluster_relation_departed,
-            self.on.cluster_relation_broken: self._on_cluster_relation_broken
+            self.on.cluster_relation_broken: self._on_cluster_relation_broken,
+            self.on.set_trusted_domain_action: self._on_set_trusted_domain_action
         }
 
         # REDIS
@@ -332,6 +333,11 @@ class NextcloudCharm(CharmBase):
     def _on_redis_available(self, event):
         utils.config_redis(self._stored.redis_info,
                            Path(self.charm_dir / 'templates'), 'redis.config.php.j2')
+
+    def _on_set_trusted_domain_action(self, event):
+        domain = event.params['domain']
+        Occ.config_system_set_trusted_domains(domain, 1)
+        self.update_config_php_trusted_domains()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Now, the one and only fqdn (index 1) can be updated with the action `set-fqdn`. I don't know if we need support for having multiple fqdn:s?